### PR TITLE
Add .prettierrc  config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dist/!(*.js.map)"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "esbuild src/parser.ts src/index.ts src/utils.ts --sourcemap --format=cjs --outdir=dist",
     "example": "pnpm build && prettier --plugin . ",
     "typeCheck": "tsc --noEmit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,8 @@ const printStylus = (
       if (node.str.includes(BLANK_LINE_PLACEHOLDER)) {
         return '';
       }
-      return node.str;
+      
+      return [b.lineSuffix(' ' + node.str.trimStart())]
     case 'rgba':
       return ((node as any).raw as string).trim();
     case 'keyframes':

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,9 @@ const printStylus = (
     case 'group': {
       return [
         b.join(b.hardline, children(node, 'nodes')),
-        options.curlyInStylus ? " {" : "",
-        child(node, "block"),
-        options.curlyInStylus ? [b.hardline, "}"] : ""
+        options.curlyInStylus ? ' {' : '',
+        child(node, 'block'),
+        options.curlyInStylus ? [b.hardline, '}'] : ''
       ];
     }
     case 'selector': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,8 @@ const printStylus = (
       return [b.join(b.hardline, children(node, 'nodes')), b.hardline];
     case 'group': {
       return [
-        [
-          b.join(', ', children(node, "nodes")),
-          options.curlyInStylus ? '{' : ''
-        ],
+        b.join(', ', children(node, "nodes")),
+        options.curlyInStylus ? '{' : '',
         child(node, "block"),
         b.hardline,
         options.curlyInStylus ? '}' : ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,8 @@ const printStylus = (
       return [b.join(b.hardline, children(node, 'nodes')), b.hardline];
     case 'group': {
       return [
-        [
-          b.join(', ', children(node, "nodes")),
-          options.curlyInStylus ? '{' : ''
-        ],
+        b.join(', ', children(node, "nodes")),
+        options.curlyInStylus ? '{' : ''
         child(node, "block"),
         b.hardline,
         options.curlyInStylus ? '}' : ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,11 +76,10 @@ const printStylus = (
       return [b.join(b.hardline, children(node, 'nodes')), b.hardline];
     case 'group': {
       return [
-        b.join(', ', children(node, "nodes")),
-        options.curlyInStylus ? '{' : '',
+        b.join(b.hardline, children(node, 'nodes')),
+        options.curlyInStylus ? " {" : "",
         child(node, "block"),
-        b.hardline,
-        options.curlyInStylus ? '}' : ''
+        options.curlyInStylus ? [b.hardline, "}"] : ""
       ];
     }
     case 'selector': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,13 @@ const printStylus = (
       return [b.join(b.hardline, children(node, 'nodes')), b.hardline];
     case 'group': {
       return [
-        b.join(b.hardline, children(node, 'nodes')),
+        b.join(b.hardline, children(node, 'nodes')).parts.map(part => {
+          if (!Array.isArray(part)) {
+            return part
+          }
+          // Remove the space inserted after the selector
+          return part.filter(s => typeof s !== 'string' || s.replaceAll(' ', '') !== '')
+        }),
         options.curlyInStylus ? ' {' : '',
         child(node, 'block'),
         options.curlyInStylus ? [b.hardline, '}'] : ''

--- a/tests/config/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/config/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,224 @@
+// Vitest Snapshot v1
+
+exports[`basic.styl 1`] = `
+a, div {
+  color: white 
+  span {
+    background rgba(0,0,0,1)
+    color #ff00e3;
+    border #9C9C9C  2rpx solid
+  }
+}
+
+.cl {
+  display: flex}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a
+div {
+  color: white;
+  span {
+    background: rgba(0, 0, 0, 1);
+    color: #ff00e3;
+    border: #9C9C9C 2rpx solid;
+  }
+}
+
+.cl {
+  display: flex;
+}
+
+`;
+
+exports[`basic.vue 1`] = `
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus">
+
+
+font-size = 14px
+
+body
+   font font-size Arial, sans-serif
+   text-color = white
+   
+   p
+    color text-color
+
+
+#logo
+   position: absolute
+   top: 50%
+   left: 50%
+   width: w = 150px
+   height: h = 80px
+   margin-left: -(w / 2)
+   margin-top: -(h / 2)
+</style>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <div></div>
+</template>
+
+<style lang="stylus">
+font-size = 14px
+
+body {
+  font: font-size Arial, sans-serif;
+  text-color = white
+
+  p {
+    color: text-color;
+
+
+  }
+}
+#logo {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: w = 150px;
+  height: h = 80px;
+  margin-left: -(w / 2);
+  margin-top: -(h / 2);
+}
+</style>
+
+`;
+
+exports[`blank.vue 1`] = `
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus">
+
+
+</style>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <div></div>
+</template>
+
+<style lang="stylus"></style>
+
+`;
+
+exports[`comment.styl 1`] = `
+// BOF comment
+a, div {   // inline comment
+  color: white   // comment
+  // another comment
+  /* asjlfk
+  */ span {
+    background rgba(0,0,0,1) // comment 1
+    // comment 2
+  }
+}
+
+$a = 1 // comment on top-level decl
+
+     /* 
+This is a comment
+  */ // EOF comment~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// BOF comment
+a
+div {
+  // inline comment
+  color: white // comment;
+  // another comment
+  /* asjlfk
+  */
+  span {
+    background: rgba(0, 0, 0, 1) // comment 1;
+    // comment 2
+  }
+}
+
+$a = 1 // comment on top-level decl
+
+/* 
+This is a comment
+  */
+// EOF comment
+
+`;
+
+exports[`empty.vue 1`] = `
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus"></style>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <div></div>
+</template>
+
+<style lang="stylus"></style>
+
+`;
+
+exports[`interpolation.styl 1`] = `
+    for size in 48  64 80 96 112 144 
+        &-{size }
+            width size px
+            height size px~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+for size in 48 64 80 96 112 144
+  &-{size} {
+    width: size px;
+    height: size px;
+  }
+
+`;
+
+exports[`mixins.styl 1`] = `
+flex()
+  display flex
+
+
+wh(w,h)
+  width w
+  height: h;
+
+
+add(a, b=1)
+  a + b
+
+add(a,   b =unit(a,px))
+  a +b
+
+div.some-layer
+  flex()
+  flex-direction column
+  wh(add(1px,3), 2em);
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+flex()
+  display: flex;
+
+
+wh(w, h)
+  width: w;
+  height: h;
+
+
+add(a, b = 1)
+  a + b
+
+add(a, b = unit(a, px))
+  a + b
+
+div.some-layer {
+  flex()
+  flex-direction: column;
+  wh(add(1px, 3), 2em)
+}
+
+`;
+
+exports[`rest.styl 1`] = `
+shadow(offset-x, args...)
+  box-shadow: offset-x args
+  margin-top: offset-x~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+shadow(offset-x, args...)
+  box-shadow: offset-x args;
+  margin-top: offset-x;
+
+`;

--- a/tests/config/basic.styl
+++ b/tests/config/basic.styl
@@ -1,0 +1,11 @@
+a, div {
+  color: white 
+  span {
+    background rgba(0,0,0,1)
+    color #ff00e3;
+    border #9C9C9C  2rpx solid
+  }
+}
+
+.cl {
+  display: flex}

--- a/tests/config/basic.vue
+++ b/tests/config/basic.vue
@@ -1,0 +1,26 @@
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus">
+
+
+font-size = 14px
+
+body
+   font font-size Arial, sans-serif
+   text-color = white
+   
+   p
+    color text-color
+
+
+#logo
+   position: absolute
+   top: 50%
+   left: 50%
+   width: w = 150px
+   height: h = 80px
+   margin-left: -(w / 2)
+   margin-top: -(h / 2)
+</style>

--- a/tests/config/blank.vue
+++ b/tests/config/blank.vue
@@ -1,0 +1,8 @@
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus">
+
+
+</style>

--- a/tests/config/comment.styl
+++ b/tests/config/comment.styl
@@ -1,0 +1,16 @@
+// BOF comment
+a, div {   // inline comment
+  color: white   // comment
+  // another comment
+  /* asjlfk
+  */ span {
+    background rgba(0,0,0,1) // comment 1
+    // comment 2
+  }
+}
+
+$a = 1 // comment on top-level decl
+
+     /* 
+This is a comment
+  */ // EOF comment

--- a/tests/config/empty.vue
+++ b/tests/config/empty.vue
@@ -1,0 +1,5 @@
+<template>
+    <div></div>
+</template>
+
+<style lang="stylus"></style>

--- a/tests/config/interpolation.styl
+++ b/tests/config/interpolation.styl
@@ -1,0 +1,4 @@
+    for size in 48  64 80 96 112 144 
+        &-{size }
+            width size px
+            height size px

--- a/tests/config/jsfmt.spec.js
+++ b/tests/config/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { curlyInStylus: true, colonSepInStylus: true, semiInStylus: true });

--- a/tests/config/mixins.styl
+++ b/tests/config/mixins.styl
@@ -1,0 +1,20 @@
+flex()
+  display flex
+
+
+wh(w,h)
+  width w
+  height: h;
+
+
+add(a, b=1)
+  a + b
+
+add(a,   b =unit(a,px))
+  a +b
+
+div.some-layer
+  flex()
+  flex-direction column
+  wh(add(1px,3), 2em);
+  

--- a/tests/config/rest.styl
+++ b/tests/config/rest.styl
@@ -1,0 +1,3 @@
+shadow(offset-x, args...)
+  box-shadow: offset-x args
+  margin-top: offset-x


### PR DESCRIPTION
@lsdsjy 
Hi! Thanks for the great plugin!
I implemented this PR because I needed a little additional functionality.

The original implementation is limited to Pythonic Style, so I added configurations to .prettierrc.

```javascript
const options = {
  curlyInStylus: {
      type: 'boolean',
      category: 'Global',
      default: false,
      description: 'Use a curly in  boolean flag',
  },
  colonSepInStylus: {
      type: 'boolean',
      category: 'Global',
      default: false,
      description: 'Use a colon as separator boolean flag',
  },
  semiInStylus: {
    type: 'boolean',
    category: 'Global',
    default: false,
    description: 'Use a semiclon as EOL boolean flag',
  }
};
```



